### PR TITLE
Move expect into dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 0.0.3
+
+Move `expect` back into `dependencies`.
+
 # 0.0.2
 
 Fixed bug in deployment.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "pg-fusion",
   "version": "0.0.2",
   "description": "Single interface for entire PostgreSQL workflow",
-  "keywords": ["postgres", "database", "sql", "migrations"],
+  "keywords": [
+    "postgres",
+    "database",
+    "sql",
+    "migrations"
+  ],
   "homepage": "https://brandonchinn178.github.io/pg-fusion",
   "bugs": "https://github.com/brandonchinn178/pg-fusion/issues",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-fusion",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Single interface for entire PostgreSQL workflow",
   "keywords": [
     "postgres",

--- a/package.json
+++ b/package.json
@@ -26,15 +26,8 @@
     "test": "TEST_TYPE=unit jest",
     "test:e2e": "TEST_TYPE=e2e jest --runInBand"
   },
-  "peerDependencies": {
-    "expect": "*"
-  },
-  "peerDependenciesMeta": {
-    "expect": {
-      "optional": true
-    }
-  },
   "dependencies": {
+    "expect": "^26.6.2",
     "node-pg-migrate": "^5.8.1",
     "pg": "^8.4.2"
   },
@@ -49,7 +42,6 @@
     "eslint-plugin-jest": "^24.1.3",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-simple-import-sort": "^6.0.1",
-    "expect": "^26.6.2",
     "fast-check": "^2.5.0",
     "jest": "^26.6.1",
     "prettier": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4412,11 +4412,6 @@ fsevents@^2.1.2:
     prettier: ^2.2.1
     ts-jest: ^26.4.1
     typescript: ^4.0.3
-  peerDependencies:
-    expect: "*"
-  peerDependenciesMeta:
-    expect:
-      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Turns out `expect` shouldn't be a peer dependency: we're extending the global `expect` object in the user's runtime, which doesn't require `expect` to be a peer dep (it's not a plugin, it's runtime modification). We're only using `expect` in `pg-fusion` for types, the `equals` helper function, and `setMatchers`, which takes in an `expect` object to modify, so it's ok to have a separate `expect` installation for `pg-fusion` as the user's project