### PR TITLE
Break up insert into two functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+Break up `db.insert()` and `client.insert()` into `.insert()` and `.insertWith()`, where `.insert()` no longer takes any options and returns `Promise<T>` and `insertWith` requires options and returns `Promise<T | null>`.
+
 # 0.0.4
 
 Add `db.insert()` and `client.insert()`, which inserts a single record and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.1.0
+
 Break up `db.insert()` and `client.insert()` into `.insert()` and `.insertWith()`, where `.insert()` no longer takes any options and returns `Promise<T>` and `insertWith` requires options and returns `Promise<T | null>`.
 
 # 0.0.4

--- a/docs/index.md
+++ b/docs/index.md
@@ -249,7 +249,7 @@ A `DatabaseClient` represents a connection to a PostgreSQL database. You should 
 
   Execute all the given queries in a single transaction.
 
-* `client.insert<T>(table: string, record: Partial<T>, options?: InsertOptions): Promise<T | null>`
+* `client.insert<T>(table: string, record: Partial<T>): Promise<T>`
 
   Insert the given record into the given table. Returns the inserted row, with default values populated:
 
@@ -260,9 +260,11 @@ A `DatabaseClient` represents a connection to a PostgreSQL database. You should 
   //   INSERT INTO my_table (foo, bar) VALUES ($1, $2) RETURNING * -- ['hello', 1]
   ```
 
-  `insert` also accepts the following options:
+* `client.insertWith<T>(table: string, record: Partial<T>, options: InsertOptions): Promise<T | null>`
 
-  * `onConflict`: What to do in event of inserting duplicate rows. By default, throws an error. This option may also be set to:
+  Same as `client.insert()` except allows passing in the following options:
+
+  * `onConflict`: What to do in event of inserting duplicate rows. When not specified, throws an error. This option may also be set to:
     * The string `'ignore'`, which is an alias for `{ action: 'ignore' }`
     * An object with:
       * `action`: either `'ignore'` or `'update'`:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-fusion",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "Single interface for entire PostgreSQL workflow",
   "keywords": [
     "postgres",

--- a/src/connection/client.spec.ts
+++ b/src/connection/client.spec.ts
@@ -214,11 +214,11 @@ describe('DatabaseClient', () => {
       )
     })
 
-    it('returns null if no rows come back', async () => {
+    it('errors if no rows come back', async () => {
       const { client } = mkClient()
       jest.spyOn(client, 'query').mockResolvedValue([])
 
-      await expect(client.insert('song', song)).resolves.toBeNull()
+      await expect(client.insert('song', song)).rejects.toThrow()
     })
 
     it('errors if multiple rows come back', async () => {
@@ -226,6 +226,44 @@ describe('DatabaseClient', () => {
       jest.spyOn(client, 'query').mockResolvedValue([{}, {}])
 
       await expect(client.insert('song', song)).rejects.toThrow()
+    })
+  })
+
+  describe('.insertWith()', () => {
+    const song = { name: 'Take On Me', artist: 'A-ha', rating: 5 }
+
+    it('inserts the given record', async () => {
+      const newSong = { id: 1, ...song }
+
+      const { client } = mkClient()
+      jest.spyOn(client, 'query').mockResolvedValue([newSong])
+
+      await expect(client.insertWith('song', song, {})).resolves.toBe(newSong)
+
+      expect(client.query).toHaveBeenCalledWith(
+        expect.sqlMatching({
+          text: `
+            INSERT INTO "song" ("name","artist","rating")
+            VALUES ($1,$2,$3)
+            RETURNING *
+          `,
+          values: ['Take On Me', 'A-ha', 5],
+        }),
+      )
+    })
+
+    it('returns null if no rows come back', async () => {
+      const { client } = mkClient()
+      jest.spyOn(client, 'query').mockResolvedValue([])
+
+      await expect(client.insertWith('song', song, {})).resolves.toBeNull()
+    })
+
+    it('errors if multiple rows come back', async () => {
+      const { client } = mkClient()
+      jest.spyOn(client, 'query').mockResolvedValue([{}, {}])
+
+      await expect(client.insertWith('song', song, {})).rejects.toThrow()
     })
   })
 

--- a/src/connection/client.ts
+++ b/src/connection/client.ts
@@ -112,7 +112,21 @@ export class DatabaseClient {
   async insert<T extends SqlRecord>(
     table: string,
     record: Partial<T>,
-    options?: InsertOptions,
+  ): Promise<T> {
+    const result = await this.insertWith(table, record, {})
+    if (result === null) {
+      throw new Error('DatabaseClient.insert() unexpectedly returned nothing')
+    }
+    return result
+  }
+
+  /**
+   * Same as 'insert', except also takes in options.
+   */
+  async insertWith<T extends SqlRecord>(
+    table: string,
+    record: Partial<T>,
+    options: InsertOptions,
   ): Promise<T | null> {
     const query = mkInsertQuery(table, record, options)
     const rows = await this.query<T>(query)

--- a/src/connection/database.e2e-spec.ts
+++ b/src/connection/database.e2e-spec.ts
@@ -164,12 +164,41 @@ describe('Database', () => {
       ])
     })
 
+    it('errors when inserting duplicates', async () => {
+      await db.insert('person', { name: 'Alice' })
+
+      await expect(
+        db.insert('person', { name: 'Alice', age: 20 }),
+      ).rejects.toThrow()
+    })
+  })
+
+  describe('.insertWith()', () => {
+    beforeEach(initTestTable)
+
+    it('can insert a record, returning the inserted row with default columns populated', async () => {
+      const result = {
+        id: expect.any(Number),
+        name: 'Alice',
+        age: null,
+        created_at: expect.any(Date),
+      }
+
+      await expect(
+        db.insertWith('person', { name: 'Alice' }, {}),
+      ).resolves.toEqual(result)
+
+      await expect(db.query(sql`SELECT * FROM "person"`)).resolves.toEqual([
+        result,
+      ])
+    })
+
     describe('inserting duplicates', () => {
       it('errors without onConflict specified', async () => {
         await db.insert('person', { name: 'Alice' })
 
         await expect(
-          db.insert('person', { name: 'Alice', age: 20 }),
+          db.insertWith('person', { name: 'Alice', age: 20 }, {}),
         ).rejects.toThrow()
       })
 
@@ -177,7 +206,7 @@ describe('Database', () => {
         await db.insert('person', { name: 'Alice' })
 
         await expect(
-          db.insert(
+          db.insertWith(
             'person',
             { name: 'Alice', age: 20 },
             {
@@ -191,7 +220,7 @@ describe('Database', () => {
         await db.insert('person', { name: 'Alice' })
 
         await expect(
-          db.insert(
+          db.insertWith(
             'person',
             { name: 'Alice', age: 20 },
             {
@@ -207,7 +236,7 @@ describe('Database', () => {
 
       it('noops with onConflict=ignore using column', async () => {
         await db.insert('person', { name: 'Alice' })
-        await db.insert(
+        await db.insertWith(
           'person',
           { name: 'Alice', age: 20 },
           {
@@ -225,7 +254,7 @@ describe('Database', () => {
 
       it('noops with onConflict=ignore using constraint', async () => {
         await db.insert('person', { name: 'Alice' })
-        await db.insert(
+        await db.insertWith(
           'person',
           { name: 'Alice', age: 20 },
           {
@@ -248,7 +277,7 @@ describe('Database', () => {
 
         await db.insert('person', { name: 'Alice' })
         await expect(
-          db.insert(
+          db.insertWith(
             'person',
             { name: 'Alice', age: 20 },
             {
@@ -268,7 +297,7 @@ describe('Database', () => {
 
         await db.insert('person', { name: 'Alice' })
         await expect(
-          db.insert(
+          db.insertWith(
             'person',
             { name: 'Alice', age: 20 },
             {
@@ -285,7 +314,7 @@ describe('Database', () => {
         await db.insert('person', { name: 'Alice' })
 
         await expect(
-          db.insert(
+          db.insertWith(
             'person',
             { name: 'Alice', age: 20 },
             {
@@ -304,7 +333,7 @@ describe('Database', () => {
 
       it('updates duplicates with onConflict=update using constraint', async () => {
         await db.insert('person', { name: 'Alice' })
-        await db.insert(
+        await db.insertWith(
           'person',
           { name: 'Alice', age: 20 },
           {
@@ -327,7 +356,7 @@ describe('Database', () => {
 
         await db.insert('person', { name: 'Alice' })
         await expect(
-          db.insert(
+          db.insertWith(
             'person',
             { name: 'Alice', age: 20 },
             {
@@ -347,7 +376,7 @@ describe('Database', () => {
 
         await db.insert('person', { name: 'Alice' })
         await expect(
-          db.insert(
+          db.insertWith(
             'person',
             { name: 'Alice', age: 20 },
             {

--- a/src/connection/database.spec.ts
+++ b/src/connection/database.spec.ts
@@ -206,20 +206,46 @@ describe('Database', () => {
           fc.string(),
           fc.anything(),
           fc.anything(),
-          fc.anything(),
-          async (table, record, options, result) => {
+          async (table, record, result) => {
             const client = { insert: jest.fn().mockResolvedValue(result) }
 
             const db = mkDatabaseWithMockedClient(client)
             await expect(
-              db.insert(
+              db.insert(table, record as Record<string, unknown>),
+            ).resolves.toBe(result)
+
+            expect(client.insert).toHaveBeenCalledWith(table, record)
+          },
+        ),
+      )
+    })
+  })
+
+  describe('.insertWith()', () => {
+    it('proxies to DatabaseClient', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.string(),
+          fc.anything(),
+          fc.anything(),
+          fc.anything(),
+          async (table, record, options, result) => {
+            const client = { insertWith: jest.fn().mockResolvedValue(result) }
+
+            const db = mkDatabaseWithMockedClient(client)
+            await expect(
+              db.insertWith(
                 table,
                 record as Record<string, unknown>,
                 options as InsertOptions,
               ),
             ).resolves.toBe(result)
 
-            expect(client.insert).toHaveBeenCalledWith(table, record, options)
+            expect(client.insertWith).toHaveBeenCalledWith(
+              table,
+              record,
+              options,
+            )
           },
         ),
       )

--- a/src/connection/database.ts
+++ b/src/connection/database.ts
@@ -88,9 +88,18 @@ export class Database {
   async insert<T extends SqlRecord>(
     table: string,
     record: Partial<T>,
-    options?: InsertOptions,
+  ): Promise<T> {
+    return this.withClient((client) => client.insert<T>(table, record))
+  }
+
+  async insertWith<T extends SqlRecord>(
+    table: string,
+    record: Partial<T>,
+    options: InsertOptions,
   ): Promise<T | null> {
-    return this.withClient((client) => client.insert<T>(table, record, options))
+    return this.withClient((client) =>
+      client.insertWith<T>(table, record, options),
+    )
   }
 
   async insertAll<T extends SqlRecord>(


### PR DESCRIPTION
It's extremely annoying to have to handle the `null` case when calling `.insert()` without specifying `onConflict`, since `.insert()` will never return `null` in this case. Unfortunately, I can't seem to figure out how to tell typescript to change the result type based on:
* whether the `options` argument exists, or
* ideally, whether `onConflict` is set to `ignore`

This is the best I could come up with, for the common case of inserting without specifying options. Can tweak later.