### PR TITLE
Combine insert + insertWith

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Return inserted rows in `insertAll`
+* `insertAll` accepts partial records, just like `insert`
 
 # 0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Return inserted rows in `insertAll`
 * `insertAll` accepts partial records, just like `insert`
+* `insert` and `insertWith` are now combined into a single `insert` function. The function is smart enough to inspect the options and return `T | null` only if `onConflict=ignore`, and `T` otherwise.
 
 # 0.1.1
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -280,9 +280,9 @@ A `DatabaseClient` represents a connection to a PostgreSQL database. You should 
       * `column`: The column with a `UNIQUE` constraint to check for conflicts. Cannot be specified with `constraint`.
       * `constraint`: The name of the constraint to check for conflicts. Cannot be specified with `column`.
 
-* `client.insertAll<T>(table: string, records: T[], options?: InsertOptions): Promise<void>`
+* `client.insertAll<T>(table: string, records: Partial<T>[], options?: InsertOptions): Promise<T[]>`
 
-  Insert the given records into the given table, throwing away the result. The records may contain different columns; e.g. if the record had fields `foo` and `bar` and an optional field `baz`:
+  Insert the given records into the given table, returning the created rows. The records may contain different columns; e.g. if the record had fields `foo` and `bar` and an optional field `baz`:
 
   ```ts
   await client.insertAll('my_table', [
@@ -295,7 +295,7 @@ A `DatabaseClient` represents a connection to a PostgreSQL database. You should 
   //   INSERT INTO my_table (foo, bar, baz) VALUES ($1, $2, $3) -- ['world', 0, 'a']
   ```
 
-  Accepts the same options as `client.insert`.
+  Accepts the same options as `client.insertWith`. If specifying `onConflict=ignore`, ignored duplicate rows will **not** be included in the returned rows.
 
 * `client.migrate(options?: MigrateOptions): Promise<void>`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -256,7 +256,7 @@ A `DatabaseClient` represents a connection to a PostgreSQL database. You should 
 
   Execute all the given queries in a single transaction.
 
-* `client.insert<T>(table: string, record: Partial<T>): Promise<T>`
+* `client.insert<T, Options extends InsertOptions>(table: string, record: Partial<T>, options?: Options): Promise<InsertResult<T, Options>>`
 
   Insert the given record into the given table. Returns the inserted row, with default values populated:
 
@@ -265,17 +265,17 @@ A `DatabaseClient` represents a connection to a PostgreSQL database. You should 
 
   // runs:
   //   INSERT INTO my_table (foo, bar) VALUES ($1, $2) RETURNING * -- ['hello', 1]
+  // returns:
+  //   { id: 1, foo: 'hello', bar: 1, baz: null }
   ```
 
-* `client.insertWith<T>(table: string, record: Partial<T>, options: InsertOptions): Promise<T | null>`
-
-  Same as `client.insert()` except allows passing in the following options:
+  By default, returns the nonnullable `Promise<T>`, but this function also accepts the following options, which may change the return type:
 
   * `onConflict`: What to do in event of inserting duplicate rows. When not specified, throws an error. This option may also be set to:
     * The string `'ignore'`, which is an alias for `{ action: 'ignore' }`
     * An object with:
       * `action`: either `'ignore'` or `'update'`:
-          * `ignore` means to ignore duplicate rows. If a duplicate row was ignored, `.insert()` returns `null`.
+          * `ignore` means to ignore duplicate rows. Changes the return type to `Promise<T | null>`, returning `null` if a duplicate row was ignored.
           * `update` means to replace the existing row with the record being inserted. If `update` is specified, either `column` or `constraint` MUST be specified.
       * `column`: The column with a `UNIQUE` constraint to check for conflicts. Cannot be specified with `constraint`.
       * `constraint`: The name of the constraint to check for conflicts. Cannot be specified with `column`.
@@ -295,7 +295,7 @@ A `DatabaseClient` represents a connection to a PostgreSQL database. You should 
   //   INSERT INTO my_table (foo, bar, baz) VALUES ($1, $2, $3) -- ['world', 0, 'a']
   ```
 
-  Accepts the same options as `client.insertWith`. If specifying `onConflict=ignore`, ignored duplicate rows will **not** be included in the returned rows.
+  Accepts the same options as `client.insert`. If specifying `onConflict=ignore`, ignored duplicate rows will **not** be included in the returned rows.
 
 * `client.migrate(options?: MigrateOptions): Promise<void>`
 

--- a/src/connection/client.spec.ts
+++ b/src/connection/client.spec.ts
@@ -192,44 +192,6 @@ describe('DatabaseClient', () => {
   })
 
   describe('.insert()', () => {
-    const song = { name: 'Take On Me', artist: 'A-ha', rating: 5 }
-
-    it('inserts the given record', async () => {
-      const newSong = { id: 1, ...song }
-
-      const { client } = mkClient()
-      jest.spyOn(client, 'query').mockResolvedValue([newSong])
-
-      await expect(client.insert('song', song)).resolves.toBe(newSong)
-
-      expect(client.query).toHaveBeenCalledWith(
-        expect.sqlMatching({
-          text: `
-            INSERT INTO "song" ("name","artist","rating")
-            VALUES ($1,$2,$3)
-            RETURNING *
-          `,
-          values: ['Take On Me', 'A-ha', 5],
-        }),
-      )
-    })
-
-    it('errors if no rows come back', async () => {
-      const { client } = mkClient()
-      jest.spyOn(client, 'query').mockResolvedValue([])
-
-      await expect(client.insert('song', song)).rejects.toThrow()
-    })
-
-    it('errors if multiple rows come back', async () => {
-      const { client } = mkClient()
-      jest.spyOn(client, 'query').mockResolvedValue([{}, {}])
-
-      await expect(client.insert('song', song)).rejects.toThrow()
-    })
-  })
-
-  describe('.insertWith()', () => {
     type Song = typeof song & { id: number }
     const song = { name: 'Take On Me', artist: 'A-ha', rating: 5 }
 
@@ -239,8 +201,8 @@ describe('DatabaseClient', () => {
       const { client } = mkClient()
       jest.spyOn(client, 'query').mockResolvedValue([newSong])
 
-      // insertWith should be not nullable by default
-      const result: Song = await client.insertWith<Song>('song', song, {})
+      // insert should be not nullable by default
+      const result: Song = await client.insert<Song>('song', song)
       expect(result).toBe(newSong)
 
       expect(client.query).toHaveBeenCalledWith(
@@ -259,15 +221,15 @@ describe('DatabaseClient', () => {
       const { client } = mkClient()
       jest.spyOn(client, 'query').mockResolvedValue([])
 
-      await expect(client.insertWith('song', song, {})).rejects.toThrow()
+      await expect(client.insert('song', song)).rejects.toThrow()
     })
 
     it('returns null if no rows come back with onConflict=ignore', async () => {
       const { client } = mkClient()
       jest.spyOn(client, 'query').mockResolvedValue([])
 
-      // insertWith should be nullable when onConflict=ignore
-      const result: Song | null = await client.insertWith<Song>('song', song, {
+      // insert should be nullable when onConflict=ignore
+      const result: Song | null = await client.insert<Song>('song', song, {
         onConflict: 'ignore',
       })
       expect(result).toBeNull()
@@ -277,7 +239,7 @@ describe('DatabaseClient', () => {
       const { client } = mkClient()
       jest.spyOn(client, 'query').mockResolvedValue([{}, {}])
 
-      await expect(client.insertWith('song', song, {})).rejects.toThrow()
+      await expect(client.insert('song', song)).rejects.toThrow()
     })
   })
 

--- a/src/connection/client.ts
+++ b/src/connection/client.ts
@@ -125,27 +125,13 @@ export class DatabaseClient {
    *     artist: 'A-ha',
    *   })
    */
-  async insert<T extends SqlRecord>(
-    table: string,
-    record: Partial<T>,
-  ): Promise<T> {
-    const result = await this.insertWith(table, record, {})
-    if (result === null) {
-      throw new Error('DatabaseClient.insert() unexpectedly returned nothing')
-    }
-    return result
-  }
-
-  /**
-   * Same as 'insert', except also takes in options.
-   */
-  async insertWith<
+  async insert<
     T extends SqlRecord,
     Options extends InsertOptions = Record<string, unknown>
   >(
     table: string,
     record: Partial<T>,
-    options: Options,
+    options?: Options,
   ): Promise<InsertResult<T, Options>> {
     const query = mkInsertQuery(table, record, options)
     const rows = await this.query<T>(query)
@@ -171,11 +157,7 @@ export class DatabaseClient {
 
     await this.transaction(async () => {
       for (const record of records) {
-        const row = await this.insertWith<T, InsertOptions>(
-          table,
-          record,
-          options ?? {},
-        )
+        const row = await this.insert<T, InsertOptions>(table, record, options)
         if (row) {
           result.push(row)
         }

--- a/src/connection/client.ts
+++ b/src/connection/client.ts
@@ -159,7 +159,7 @@ export class DatabaseClient {
    */
   async insertAll<T extends SqlRecord>(
     table: string,
-    records: T[],
+    records: Partial<T>[],
     options?: InsertOptions,
   ): Promise<T[]> {
     const result: T[] = []

--- a/src/connection/client.ts
+++ b/src/connection/client.ts
@@ -2,7 +2,12 @@ import migrate from 'node-pg-migrate'
 import * as pg from 'pg'
 
 import { sql, SqlQuery } from '../sql'
-import { InsertOptions, mkInsertQuery } from './insert'
+import {
+  InsertOptions,
+  InsertResult,
+  mkInsertQuery,
+  toInsertResult,
+} from './insert'
 import { MigrateOptions } from './migrate'
 
 export type SqlRecord = Record<string, unknown>
@@ -134,17 +139,17 @@ export class DatabaseClient {
   /**
    * Same as 'insert', except also takes in options.
    */
-  async insertWith<T extends SqlRecord>(
+  async insertWith<
+    T extends SqlRecord,
+    Options extends InsertOptions = Record<string, unknown>
+  >(
     table: string,
     record: Partial<T>,
-    options: InsertOptions,
-  ): Promise<T | null> {
+    options: Options,
+  ): Promise<InsertResult<T, Options>> {
     const query = mkInsertQuery(table, record, options)
     const rows = await this.query<T>(query)
-    if (rows.length > 1) {
-      throw new Error(`INSERT statement returned multiple rows: ${rows}`)
-    }
-    return rows.length === 1 ? rows[0] : null
+    return toInsertResult(rows, options)
   }
 
   /**
@@ -166,7 +171,11 @@ export class DatabaseClient {
 
     await this.transaction(async () => {
       for (const record of records) {
-        const row = await this.insertWith<T>(table, record, options ?? {})
+        const row = await this.insertWith<T, InsertOptions>(
+          table,
+          record,
+          options ?? {},
+        )
         if (row) {
           result.push(row)
         }

--- a/src/connection/database.e2e-spec.ts
+++ b/src/connection/database.e2e-spec.ts
@@ -179,41 +179,20 @@ describe('Database', () => {
       ])
     })
 
-    it('errors when inserting duplicates', async () => {
-      await db.insert('person', { name: 'Alice' })
-
-      await expect(
-        db.insert('person', { name: 'Alice', age: 20 }),
-      ).rejects.toThrow()
-    })
-  })
-
-  describe('.insertWith()', () => {
-    beforeEach(initTestTable)
-
-    it('can insert a record, returning the inserted row with default columns populated', async () => {
-      const result = {
-        id: expect.any(Number),
-        name: 'Alice',
-        age: null,
-        created_at: expect.any(Date),
-      }
-
-      await expect(
-        db.insertWith('person', { name: 'Alice' }, {}),
-      ).resolves.toEqual(result)
-
-      await expect(db.query(sql`SELECT * FROM "person"`)).resolves.toEqual([
-        result,
-      ])
-    })
-
     describe('inserting duplicates', () => {
+      it('errors with no options specified', async () => {
+        await db.insert('person', { name: 'Alice' })
+
+        await expect(
+          db.insert('person', { name: 'Alice', age: 20 }),
+        ).rejects.toThrow()
+      })
+
       it('errors without onConflict specified', async () => {
         await db.insert('person', { name: 'Alice' })
 
         await expect(
-          db.insertWith('person', { name: 'Alice', age: 20 }, {}),
+          db.insert('person', { name: 'Alice', age: 20 }, {}),
         ).rejects.toThrow()
       })
 
@@ -221,13 +200,7 @@ describe('Database', () => {
         await db.insert('person', { name: 'Alice' })
 
         await expect(
-          db.insertWith(
-            'person',
-            { name: 'Alice', age: 20 },
-            {
-              onConflict: null,
-            },
-          ),
+          db.insert('person', { name: 'Alice', age: 20 }, { onConflict: null }),
         ).rejects.toThrow()
       })
 
@@ -235,12 +208,10 @@ describe('Database', () => {
         await db.insert('person', { name: 'Alice' })
 
         await expect(
-          db.insertWith(
+          db.insert(
             'person',
             { name: 'Alice', age: 20 },
-            {
-              onConflict: 'ignore',
-            },
+            { onConflict: 'ignore' },
           ),
         ).resolves.toBeNull()
 
@@ -251,7 +222,7 @@ describe('Database', () => {
 
       it('noops with onConflict=ignore using column', async () => {
         await db.insert('person', { name: 'Alice' })
-        await db.insertWith(
+        await db.insert(
           'person',
           { name: 'Alice', age: 20 },
           {
@@ -269,7 +240,7 @@ describe('Database', () => {
 
       it('noops with onConflict=ignore using constraint', async () => {
         await db.insert('person', { name: 'Alice' })
-        await db.insertWith(
+        await db.insert(
           'person',
           { name: 'Alice', age: 20 },
           {
@@ -292,7 +263,7 @@ describe('Database', () => {
 
         await db.insert('person', { name: 'Alice' })
         await expect(
-          db.insertWith(
+          db.insert(
             'person',
             { name: 'Alice', age: 20 },
             {
@@ -312,7 +283,7 @@ describe('Database', () => {
 
         await db.insert('person', { name: 'Alice' })
         await expect(
-          db.insertWith(
+          db.insert(
             'person',
             { name: 'Alice', age: 20 },
             {
@@ -329,7 +300,7 @@ describe('Database', () => {
         await db.insert('person', { name: 'Alice' })
 
         await expect(
-          db.insertWith(
+          db.insert(
             'person',
             { name: 'Alice', age: 20 },
             {
@@ -348,7 +319,7 @@ describe('Database', () => {
 
       it('updates duplicates with onConflict=update using constraint', async () => {
         await db.insert('person', { name: 'Alice' })
-        await db.insertWith(
+        await db.insert(
           'person',
           { name: 'Alice', age: 20 },
           {
@@ -371,7 +342,7 @@ describe('Database', () => {
 
         await db.insert('person', { name: 'Alice' })
         await expect(
-          db.insertWith(
+          db.insert(
             'person',
             { name: 'Alice', age: 20 },
             {
@@ -391,7 +362,7 @@ describe('Database', () => {
 
         await db.insert('person', { name: 'Alice' })
         await expect(
-          db.insertWith(
+          db.insert(
             'person',
             { name: 'Alice', age: 20 },
             {

--- a/src/connection/database.spec.ts
+++ b/src/connection/database.spec.ts
@@ -225,46 +225,20 @@ describe('Database', () => {
           fc.string(),
           fc.anything(),
           fc.anything(),
-          async (table, record, result) => {
+          fc.anything(),
+          async (table, record, options, result) => {
             const client = { insert: jest.fn().mockResolvedValue(result) }
 
             const db = mkDatabaseWithMockedClient(client)
             await expect(
-              db.insert(table, record as Record<string, unknown>),
-            ).resolves.toBe(result)
-
-            expect(client.insert).toHaveBeenCalledWith(table, record)
-          },
-        ),
-      )
-    })
-  })
-
-  describe('.insertWith()', () => {
-    it('proxies to DatabaseClient', async () => {
-      await fc.assert(
-        fc.asyncProperty(
-          fc.string(),
-          fc.anything(),
-          fc.anything(),
-          fc.anything(),
-          async (table, record, options, result) => {
-            const client = { insertWith: jest.fn().mockResolvedValue(result) }
-
-            const db = mkDatabaseWithMockedClient(client)
-            await expect(
-              db.insertWith(
+              db.insert(
                 table,
                 record as Record<string, unknown>,
                 options as InsertOptions,
               ),
             ).resolves.toBe(result)
 
-            expect(client.insertWith).toHaveBeenCalledWith(
-              table,
-              record,
-              options,
-            )
+            expect(client.insert).toHaveBeenCalledWith(table, record, options)
           },
         ),
       )

--- a/src/connection/database.ts
+++ b/src/connection/database.ts
@@ -89,23 +89,16 @@ export class Database {
     return this.withClient((client) => client.executeAll(queries))
   }
 
-  async insert<T extends SqlRecord>(
-    table: string,
-    record: Partial<T>,
-  ): Promise<T> {
-    return this.withClient((client) => client.insert<T>(table, record))
-  }
-
-  async insertWith<
+  async insert<
     T extends SqlRecord,
     Options extends InsertOptions = Record<string, unknown>
   >(
     table: string,
     record: Partial<T>,
-    options: Options,
+    options?: Options,
   ): Promise<InsertResult<T, Options>> {
     return this.withClient((client) =>
-      client.insertWith<T, Options>(table, record, options),
+      client.insert<T, Options>(table, record, options),
     )
   }
 

--- a/src/connection/database.ts
+++ b/src/connection/database.ts
@@ -2,7 +2,7 @@ import * as pg from 'pg'
 
 import { SqlQuery } from '../sql'
 import { DatabaseClient, SqlRecord } from './client'
-import { InsertOptions } from './insert'
+import { InsertOptions, InsertResult } from './insert'
 import { MigrateOptions } from './migrate'
 
 // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49567
@@ -96,13 +96,16 @@ export class Database {
     return this.withClient((client) => client.insert<T>(table, record))
   }
 
-  async insertWith<T extends SqlRecord>(
+  async insertWith<
+    T extends SqlRecord,
+    Options extends InsertOptions = Record<string, unknown>
+  >(
     table: string,
     record: Partial<T>,
-    options: InsertOptions,
-  ): Promise<T | null> {
+    options: Options,
+  ): Promise<InsertResult<T, Options>> {
     return this.withClient((client) =>
-      client.insertWith<T>(table, record, options),
+      client.insertWith<T, Options>(table, record, options),
     )
   }
 

--- a/src/connection/insert.ts
+++ b/src/connection/insert.ts
@@ -8,7 +8,7 @@ export const mkInsertQuery = <T extends Record<string, unknown>>(
   table: string,
   record: T,
   options: InsertOptions = {},
-) => {
+): SqlQuery => {
   const { onConflict = null } = options
 
   const columnNames = Object.keys(record)
@@ -38,13 +38,13 @@ const mkConflictClause = (
   columnNamesSql: SqlQuery,
   valuesSql: SqlQuery,
   options: ConflictOptions | null,
-) => {
+): SqlQuery => {
   if (options === null) {
     return sql``
   }
 
   const { action, ...target } =
-    options === 'ignore' ? { action: 'ignore' } : options
+    options === 'ignore' ? { action: 'ignore' as const } : options
 
   const targetClause =
     'constraint' in target && target.constraint


### PR DESCRIPTION
`insert` and `insertWith` are now combined into a single `insert` function. The function is smart enough to inspect the options and return `T | null` only if `onConflict=ignore`, and `T` otherwise.

```ts
// not nullable
const result1: User = client.insert('user', user)

// nullable
const result2: User | null = client.insert('user', user, { onConflict: 'ignore' })

// not nullable
const result3: User = client.insert('user', user, { onConflict: { action: 'update', column: 'name' } })
```