### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
       - install_yarn_deps
       - run:
           name: Install pre-commit
-          command: curl https://pre-commit.com/install-local.py | python -
+          command: curl https://pre-commit.com/install-local.py | python3 -
       - run:
           name: Run pre-commit
           command: pre-commit run --all-files


### PR DESCRIPTION
Python 2.7 reached EOL, `pre-commit` starting erroring with python 2
https://app.circleci.com/pipelines/github/brandonchinn178/pg-fusion/79/workflows/478f57e9-1bdf-4d77-bd00-19dd9a51b03a/jobs/224